### PR TITLE
Fixed build using Zig 0.7.0 on Gentoo Linux.

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -7,13 +7,11 @@ pub fn build(b: *Builder) void {
     exe.linkSystemLibrary("SDL2");
     exe.linkSystemLibrary("c");
 
-    b.default_step.dependOn(&exe.step);
-    b.installArtifact(exe);
+    exe.install();
 
+    const run_cmd = exe.run();
+    run_cmd.step.dependOn(b.getInstallStep());
 
-    const run = b.step("run", "Run the demo");
-    const run_cmd = b.addCommand(".", b.env_map,
-        [][]const u8{exe.getOutputPath(), });
-    run.dependOn(&run_cmd.step);
-    run_cmd.step.dependOn(&exe.step);
+    const run_step = b.step("run", "Run the app");
+    run_step.dependOn(&run_cmd.step);
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -25,20 +25,20 @@ inline fn SDL_RWclose(ctx: [*]c.SDL_RWops) c_int {
 
 pub fn main() !void {
     if (c.SDL_Init(c.SDL_INIT_VIDEO) != 0) {
-        c.SDL_Log(c"Unable to initialize SDL: %s", c.SDL_GetError());
+        c.SDL_Log("Unable to initialize SDL: %s", c.SDL_GetError());
         return error.SDLInitializationFailed;
     }
     defer c.SDL_Quit();
 
-    const screen = c.SDL_CreateWindow(c"My Game Window", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, 300, 73, c.SDL_WINDOW_OPENGL) orelse
+    const screen = c.SDL_CreateWindow("My Game Window", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, 300, 73, c.SDL_WINDOW_OPENGL) orelse
         {
-        c.SDL_Log(c"Unable to create window: %s", c.SDL_GetError());
+        c.SDL_Log("Unable to create window: %s", c.SDL_GetError());
         return error.SDLInitializationFailed;
     };
     defer c.SDL_DestroyWindow(screen);
 
     const renderer = c.SDL_CreateRenderer(screen, -1, 0) orelse {
-        c.SDL_Log(c"Unable to create renderer: %s", c.SDL_GetError());
+        c.SDL_Log("Unable to create renderer: %s", c.SDL_GetError());
         return error.SDLInitializationFailed;
     };
     defer c.SDL_DestroyRenderer(renderer);
@@ -48,19 +48,19 @@ pub fn main() !void {
         @ptrCast(*const c_void, &zig_bmp[0]),
         @intCast(c_int, zig_bmp.len),
     ) orelse {
-        c.SDL_Log(c"Unable to get RWFromConstMem: %s", c.SDL_GetError());
+        c.SDL_Log("Unable to get RWFromConstMem: %s", c.SDL_GetError());
         return error.SDLInitializationFailed;
     };
     defer assert(SDL_RWclose(rw) == 0);
 
     const zig_surface = c.SDL_LoadBMP_RW(rw, 0) orelse {
-        c.SDL_Log(c"Unable to load bmp: %s", c.SDL_GetError());
+        c.SDL_Log("Unable to load bmp: %s", c.SDL_GetError());
         return error.SDLInitializationFailed;
     };
     defer c.SDL_FreeSurface(zig_surface);
 
     const zig_texture = c.SDL_CreateTextureFromSurface(renderer, zig_surface) orelse {
-        c.SDL_Log(c"Unable to create texture from surface: %s", c.SDL_GetError());
+        c.SDL_Log("Unable to create texture from surface: %s", c.SDL_GetError());
         return error.SDLInitializationFailed;
     };
     defer c.SDL_DestroyTexture(zig_texture);


### PR DESCRIPTION
Regarding build.zig, I found that andrewrk had
fixed another project using the changes that
I imported.

https://github.com/baverman/sdl-zig-demo/commit/bfc3644b8928d76ed0fee941b9af95e4b7ea1ff7

Per Reddit, from what I gathered, all strings are now
null terminated, so the 'c' prefix before a string
is unnecessary.

https://www.reddit.com/r/Zig/comments/fq504d/cstring_literals_not_working_zig_05_on_windows_10/

Will try to get zig 0.7.0 build into main gentoo tree.