### PR TITLE
Updated event.type switch

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -46,7 +46,7 @@ pub fn main() !void {
     while (!quit) {
         var event: c.SDL_Event = undefined;
         while (c.SDL_PollEvent(&event) != 0) {
-            switch (event.@"type") {
+            switch (event.type) {
                 c.SDL_QUIT => {
                     quit = true;
                 },


### PR DESCRIPTION
The `@""` syntax in `event.@"type"` is no longer needed since `type` is a valid identifier.